### PR TITLE
Fix dark mode text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,9 +239,18 @@
         background: #2a2a2a;
         border-color: #444;
       }
+      .skill-block h3 {
+        color: #b6e2d3;
+      }
       .value-row {
         background: #2a2a2a;
         border-color: #444;
+      }
+      .need {
+        color: #b6e2d3;
+      }
+      .superpower {
+        color: #e0e0e0;
       }
       footer {
         background: #1a1a1a;


### PR DESCRIPTION
## Summary
- update dark theme colors for `.skill-block h3`, `.need`, and `.superpower`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685dbb8702e08332aa48ffbcede3cd2a