### PR TITLE
Add about-box styling and dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,14 @@
       background: #fef6f0;
       transform: scale(1.02);
     }
+    .about-box {
+      background: #fff8f0;
+      border-left: 6px solid #f4a261;
+      padding: 1rem;
+      border-radius: 1rem;
+      margin-top: 1rem;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    }
     .need, .superpower {
       display: flex;
       align-items: center;
@@ -246,6 +254,11 @@
         background: #2a2a2a;
         border-color: #444;
       }
+      .about-box {
+        background: #1f1f1f;
+        border-left: 6px solid #bb86fc;
+        color: #e0e0e0;
+      }
       .need {
         color: #b6e2d3;
       }
@@ -276,7 +289,7 @@
   <main>
   <section id="about" class="fade-in">
     <h2>About Me</h2>
-    <div style="background: #fff8f0; border-left: 6px solid #f4a261; padding: 1rem; border-radius: 1rem; margin-top: 1rem; box-shadow: 0 2px 6px rgba(0,0,0,0.05);">
+    <div class="about-box">
       <p style="margin: 0;">I help SaaS companies deliver complex, high-impact projects without compromising customer experience. By bridging deep technical acumen with strategic customer engagement, I ensure cross-functional programs not only launch successfully but also drive lasting value. Whether it's aligning stakeholders on enterprise system rollouts or building frameworks that scale retention and revenue, I bring a holistic mindset that connects technical outcomes to customer success.</p>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- refactor About section markup
- move inline styling into new `.about-box` class
- add `.about-box` styles for light and dark themes

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0de06a88332b9fd562c7baa58a9