### PR TITLE
Add purple accent to value & skills sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     .skill-block {
       background: #fffcf5;
       border: 1px solid #fae1dd;
-      border-left: 4px solid #f4a261;
+      border-left: 4px solid #bb86fc;
       padding: 1rem;
       border-radius: 1rem;
       transition: background 0.3s ease, transform 0.3s ease;
@@ -157,7 +157,7 @@
       flex-direction: column;
       background: #fffaf3;
       border: 1px solid #fae1dd;
-      border-left: 6px solid #f4a261;
+      border-left: 6px solid #bb86fc;
       padding: 1rem;
       border-radius: 1rem;
       transition: background 0.3s ease, transform 0.3s ease;
@@ -167,10 +167,10 @@
       background: #fef6f0;
       transform: scale(1.02);
     }
-    .about-box {
-      background: #fff8f0;
-      border-left: 6px solid #f4a261;
-      padding: 1rem;
+      .about-box {
+        background: #fff8f0;
+        border-left: 6px solid #f4a261;
+        padding: 1rem;
       border-radius: 1rem;
       margin-top: 1rem;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
@@ -246,6 +246,7 @@
       .skill-block {
         background: #2a2a2a;
         border-color: #444;
+        border-left: 4px solid #bb86fc;
       }
       .skill-block h3 {
         color: #b6e2d3;
@@ -253,6 +254,7 @@
       .value-row {
         background: #2a2a2a;
         border-color: #444;
+        border-left: 6px solid #bb86fc;
       }
       .about-box {
         background: #1f1f1f;


### PR DESCRIPTION
## Summary
- apply purple left borders to How I Drive Value and Skills & Tools boxes
- keep About section accent color unchanged

## Testing
- `tidy -errors -q index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc3165a448332815a2fa2982896e7