### PR TITLE
Fix resume link

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
       <a href="https://www.linkedin.com/in/mgwillison" target="_blank">
         <img src="https://cdn.jsdelivr.net/gh/simple-icons/simple-icons/icons/linkedin.svg" alt="LinkedIn" /> LinkedIn
       </a>
-      <a href="resume.pdf" download>
+      <a href="Matt%20Willison%20resume.pdf" download>
         <span style="display: inline-flex; justify-content: center; align-items: center; width: 24px; height: 24px; background-color: white; color: #e76f51; font-weight: bold; font-size: 0.75rem; text-align: center; line-height: 1; border-radius: 50%; margin-right: 0.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.2);">MW</span> Resume
       </a>
     </div>


### PR DESCRIPTION
## Summary
- update `index.html` to point the Resume button at `Matt Willison resume.pdf`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc061d588332ba4e84d823e8f8d2